### PR TITLE
Config checkboxes should maintain their state when saving post as a draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+# 3.10.1
+- Config checkboxes should maintain their state when saving post as a draft
+
 # 3.10.0
 - Added "Don't replace previous push" checkbox on create/update post so push won't replace previous one
 

--- a/class.pushnews.php
+++ b/class.pushnews.php
@@ -133,8 +133,11 @@ MYHTML;
 
 	public static function future_post_custom_hook( $post_id ) {
 		self::_debug( "future_post_custom_hook: $post_id" );
-		$sendNotification = $_POST['pushnews_send_notification'];
-		$sendEmail        = $_POST['pushnews_send_email'];
+		$sendNotification        = $_POST['pushnews_send_notification'];
+		$sendEmail               = $_POST['pushnews_send_email'];
+		$allowDuplicatePush      = $_POST['pushnews_allow_duplicate_push'];
+		$dontReplacePreviousPush = $_POST['pushnews_dont_replace_previous_push'];
+
 
 		if ( $sendNotification ) {
             self::_debug("> updating sendNotification: $sendNotification");
@@ -156,6 +159,26 @@ MYHTML;
 			);
 		} else {
 			delete_post_meta( $post_id, 'sendEmail' );
+		}
+
+		if ( $allowDuplicatePush ) {
+			update_post_meta(
+				$post_id,
+				'allowDuplicatePush',
+				$allowDuplicatePush
+			);
+		} else {
+			delete_post_meta( $post_id, 'allowDuplicatePush' );
+		}
+
+		if ( $dontReplacePreviousPush ) {
+			update_post_meta(
+				$post_id,
+				'dontReplacePreviousPush',
+				$dontReplacePreviousPush
+			);
+		} else {
+			delete_post_meta( $post_id, 'dontReplacePreviousPush' );
 		}
 	}
 

--- a/pushnews.php
+++ b/pushnews.php
@@ -5,7 +5,7 @@
  * Author:             Pushnews <developers@pushnews.eu>
  * Plugin URI:         https://www.pushnews.eu/
  * Description:        Increase your website traffic with Pushnews Web Push Notifications.
- * Version:            3.10.0
+ * Version:            3.10.1
  * Author URI:         https://www.pushnews.eu/
  * License:            GPLv2 or later
  * Text Domain:        pushnews
@@ -28,7 +28,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'PUSHNEWS_VERSION', '3.10.0' );
+define( 'PUSHNEWS_VERSION', '3.10.1' );
 define( 'PUSHNEWS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 require_once( PUSHNEWS__PLUGIN_DIR . 'class.pushnews.php' );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: push, push notifications, web push, desktop notification, notifications, p
 Requires at least: 3.8
 Tested up to: 6.0.1
 Requires PHP: 5.3
-Stable tag: 3.10.0
+Stable tag: 3.10.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -58,6 +58,9 @@ First plugin release
 4. No HTTPS website is required
 
 == Changelog ==
+
+= 3.10.1 =
+* Config checkboxes should maintain their state when saving post as a draft
 
 = 3.10.0 =
 * Added "Don't replace previous push" checkbox on create/update post so push won't replace previous one


### PR DESCRIPTION
Antes, as checkboxes
- Se uma Push já foi enviada para esse Post, permitir envio duplicado
- Não substituir a push anterior 

Não estavam mantendo o estado (checked/unchecked) ao salvar um artigo como rascunho. Esse PR corrige esse comportamento